### PR TITLE
Scrollfps - Added scrolling for the remaining tests

### DIFF
--- a/b2gperf/b2gperf.py
+++ b/b2gperf/b2gperf.py
@@ -21,6 +21,7 @@ import dzclient
 import gaiatest
 from marionette import Marionette
 from marionette import MarionetteTouchMixin
+from gestures import smooth_scroll
 import mozdevice
 
 TEST_TYPES = ['startup', 'scrollfps']
@@ -285,14 +286,32 @@ class B2GPerfRunner(DatazillaPerfPoster):
         self.marionette.__class__ = type('Marionette', (Marionette, MarionetteTouchMixin), {})
 
         self.marionette.setup_touch()
+        apps = gaiatest.GaiaApps(self.marionette)
 
         if app_name == 'Homescreen':
             self.marionette.flick(self.marionette.find_element('id', 'landing-page'), '90%', '50%', '10%', '50%', touch_duration)
             time.sleep(touch_duration / 1000)
             self.marionette.flick(self.marionette.find_elements('css selector', '.page')[1], '10%', '50%', '90%', '50%', touch_duration)
         elif app_name == 'Contacts':
-            print "SCROLL ME NOW"
-            time.sleep(25)
+            contacts = apps.launch('Contacts')
+            time.sleep(5) # wait for the contacts to load
+            names = self.marionette.find_elements("class name", "contact-item")
+            smooth_scroll(self.marionette, names[0], "y", "negative", 5000, scroll_back=False)
+            time.sleep(5)
+        elif app_name == 'Browser':
+            browser = apps.launch('Browser')
+            #navigate is misbehaving
+            self.marionette.execute_script("window.location.href='http://taskjs.org/';")
+            time.sleep(5) # wait for the page to load
+            a = self.marionette.find_element("tag name", "a")
+            smooth_scroll(self.marionette, a, "y", "negative", 5000, scroll_back=True)
+            time.sleep(5)
+        elif app_name == 'Email':
+            email = apps.launch('Email')
+            time.sleep(10) # wait for the page to load
+            emails = self.marionette.find_elements("class name", "msg-header-item")
+            smooth_scroll(self.marionette, emails[0], "y", "negative", 2000, scroll_back=True)
+            time.sleep(5)
 
 
 class dzOptionParser(OptionParser):

--- a/b2gperf/gestures.py
+++ b/b2gperf/gestures.py
@@ -1,0 +1,35 @@
+from marionette import Actions
+
+#axis is y or x
+#direction is negative or positive
+def smooth_scroll(marionette_session, start_element, axis, direction, length, increments=None, wait_period=None, scroll_back=None):
+    if axis not in ["x", "y"]:
+        raise Exception("Axis must be either 'x' or 'y'")
+    if direction not in ["negative", "positive"]:
+        raise Exception("Direction must either be negative or positive")
+    increments = increments or 100
+    wait_period = wait_period or 0.05
+    scroll_back = scroll_back or False
+    current = 0
+    if axis is "x":
+        if direction is "negative":
+            offset = [-increments, 0]
+        else:
+            offset = [increments, 0]
+    else:
+        if direction is "negative":
+            offset = [0, -increments]
+        else:
+            offset = [0, increments]
+    action = Actions(marionette_session)
+    action.press(start_element)
+    while (current < length):
+        current += increments
+        action.move_by_offset(*offset).wait(wait_period)
+    if scroll_back:
+        offset = [-value for value in offset]
+        while (current > 0):
+            current -= increments
+            action.move_by_offset(*offset).wait(wait_period)
+    action.release()
+    action.perform()


### PR DESCRIPTION
Here's the code to add scrolling on the remaining 3 tests. The browser test has issues since it aborts early right now, because stop_fps() is called during the execution of the scroll. You can either reduce the scroll amount (to around 2000), change when stop_fps() is called, or add a hook to see when 'touchend' is received on the page and then do stop_fps() then. If you want to do the latter, I can help with that tomorrow.
