### PR TITLE
race condition fix and sanity restoration 

### DIFF
--- a/b2gperf/b2gperf.py
+++ b/b2gperf/b2gperf.py
@@ -327,6 +327,7 @@ class B2GPerfRunner(DatazillaPerfPoster):
             # TODO: let's see if we can use touchend to know exactly when the scroll is finished so we aren't measuring fps while we are not actually scrolling.
         elif app_name == 'Browser':
             self.marionette.execute_script("return window.wrappedJSObject.Browser.navigate('http://taskjs.org/');", new_sandbox=False)
+            MarionetteWait(self.marionette, 30).until(lambda m: 'http://taskjs.org/' == m.execute_script('return window.wrappedJSObject.Browser.currentTab.url;', new_sandbox=False))
             MarionetteWait(self.marionette, 30).until(lambda m: not m.execute_script('return window.wrappedJSObject.Browser.currentTab.loading;', new_sandbox=False))
             # check when the tab's document is ready
             tab_frame = self.marionette.execute_script("return window.wrappedJSObject.Browser.currentTab.dom;")


### PR DESCRIPTION
The 'touchend' event was being fired before we could set up our event handler. Instead, I'm adding an event handler earlier that will just set a variable when the event occurs, so we can just check that.

I figured out that insane hack. It's because of this: https://bugzilla.mozilla.org/show_bug.cgi?id=858288. The sandbox that execute_*script runs in has to reset if we switch frames, but there's one case (switch_to_frame()) where we don't do that, and that triggers a bug where we reuse the sandbox of a different frame instead of the one we're currently in. I fixed this by removing the new_sandbox=False part on line 274. It doesn't do anything useful here anyway, other than triggering that bug.

Also, the page load checker wasn't quite right. We have to wait until we're on the right page, and the 'loading' variable is false.
