### PR TITLE
Add mozlog for console logging and debugging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ except (OSError, IOError):
     description = ''
 
 # dependencies
-deps = ['gaiatest==0.12',
-        'datazilla>=1.2',
+deps = ['datazilla>=1.2',
+        'gaiatest==0.12',
+        'mozlog==1.3',
         'progressbar==2.3']
 
 setup(name='b2gperf',


### PR DESCRIPTION
Would you mind taking a quick look over this @jonallengriffin? We have noticed the perf tests taking a lot longer on master recently but with no regressions in the metrics. The additional debug logs should help to determine where time is being spent.
