### PR TITLE
verify that scrollfps cli argument app name is a supported app

### DIFF
--- a/b2gperf/b2gperf.py
+++ b/b2gperf/b2gperf.py
@@ -28,7 +28,7 @@ from marionette.gestures import smooth_scroll
 from wait import MarionetteWait
 
 TEST_TYPES = ['startup', 'scrollfps']
-
+SCROLLFPS_APP_NAMES = ['browser', 'contacts', 'email', 'homescreen']
 
 class DatazillaPerfPoster(object):
 
@@ -161,6 +161,10 @@ class B2GPerfRunner(DatazillaPerfPoster):
             self.logger.info('Running startup tests')
             self.test_startup()
         elif test_type == 'scrollfps':
+            for app_name in self.app_names:
+                if app_name.lower() not in SCROLLFPS_APP_NAMES:
+                    self.logger.error("%s is not a valid scrollfps test app name. Please select one of %s" % (app_name, SCROLLFPS_APP_NAMES))
+                    sys.exit(1)
             self.logger.info('Running FPS tests')
             self.test_scrollfps()
         else:

--- a/b2gperf/b2gperf.py
+++ b/b2gperf/b2gperf.py
@@ -462,11 +462,6 @@ class B2GPerfRunner(DatazillaPerfPoster):
             emails = self.marionette.find_elements("class name", "msg-header-author")
             self.logger.debug('Scrolling through emails')
             smooth_scroll(self.marionette, emails[0], "y", -1, 2000, scroll_back=True)
-        else:
-            message = 'Unsupported app for scrollfps tests: %s' % app_name
-            self.logger.exception(message)
-            raise Exception(message)
-
 
 class B2GPerfFormatter(mozlog.MozFormatter):
 


### PR DESCRIPTION
If you pass in an app name that isn't supported as a scrollfps test, you get a cycle of 30 messages saying
"AssertionError: Failed to launch app with name '<appname>'"

which isn't very useful. This pr prints out a helpful message and quits before deploying the 30 test iterations.
