### PR TITLE
Add numpy to dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ except (OSError, IOError):
 deps = ['datazilla>=1.2',
         'gaiatest==0.12',
         'mozlog==1.3',
-        'progressbar==2.3']
+        'progressbar==2.3',
+        'numpy']
 
 setup(name='b2gperf',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.7'
+version = '0.7.1'
 
 # get documentation from the README
 try:


### PR DESCRIPTION
The jobs were failing for b2gperf since numpy was not added as a dependency. We'll have to update the pypi package after this lands.
