### PR TITLE
Bug 988804 - Fix wait in B2GPerfScrollMessagesTest for slower devices

### DIFF
--- a/b2gperf/b2gperf.py
+++ b/b2gperf/b2gperf.py
@@ -672,10 +672,9 @@ class B2GPerfScrollMessagesTest(B2GPerfScrollTest):
     def before_scroll(self):
         B2GPerfScrollTest.before_scroll(self)
         self.logger.debug('Waiting for messages to be displayed')
-        Wait(self.marionette, timeout=240).until(
-            expected.element_displayed(
-                self.marionette.find_element(
-                    By.CSS_SELECTOR, '#threads-container li')))
+        Wait(self.marionette).until(expected.element_displayed(
+            Wait(self.marionette, timeout=240).until(expected.element_present(
+                By.CSS_SELECTOR, '#threads-container li'))))
 
     def populate_databases(self):
         self.b2gpopulate.populate_messages(200, restart=False)

--- a/b2gperf/version.py
+++ b/b2gperf/version.py
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-__version__ = '0.22'
+__version__ = '0.23'


### PR DESCRIPTION
This changes the wait to focus first on the element being present (with a high timeout) before being displayed.
